### PR TITLE
Fix display of the player's phone number in the phone settings

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -28,6 +28,7 @@ AddEventHandler('matriarch_simcards:changeNumber', function(newNum)
     })
     xPlayer.removeInventoryItem('sim_card', 1)
     TriggerClientEvent('matriarch_simcards:success', _source, newNum)
+    TriggerClientEvent('gcPhone:myPhoneNumber', _source, newNum)
 end)
 
 -- DRIVER LICENSE CARD


### PR DESCRIPTION
When changing to a new number, the player's number wouldn't update in the settings app.

I've only tested this with this [gcPhone](https://github.com/N3MTV/gcphone/pull/305), but it should work the same.